### PR TITLE
Add navigation button for authentication Page

### DIFF
--- a/frontend/client/src/pages/forgot-password.tsx
+++ b/frontend/client/src/pages/forgot-password.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Wallet, Mail, ArrowLeft, CheckCircle, Lock, Eye, EyeOff } from "lucide-react";
+import { Wallet, Mail, ArrowLeft, CheckCircle, Lock, Eye, EyeOff, Home } from "lucide-react";
 import ParticleBackground from "@/components/particle-background";
 
 const FloatingIcon = ({ icon, className, delay = 0 }: { icon: React.ReactNode; className: string; delay?: number }) => (
@@ -348,6 +348,25 @@ export default function ForgotPassword() {
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center p-4 relative overflow-hidden">
       <div className="absolute inset-0 blockchain-grid opacity-10"></div>
       <ParticleBackground />
+      
+      {/* Back to Home Button */}
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        className="absolute top-6 right-6 z-20"
+      >
+        <Link href="/">
+          <Button
+            variant="outline"
+            size="sm"
+            className="glass-morphism border-border/30 hover:border-primary/50 hover:bg-primary/10 transition-all duration-300 hover:scale-105 shadow-lg backdrop-blur-md"
+          >
+            <Home className="w-4 h-4 mr-2" />
+            Back to Home
+          </Button>
+        </Link>
+      </motion.div>
       
       {/* Floating Icons */}
       <div className="absolute inset-0 z-5">

--- a/frontend/client/src/pages/login.tsx
+++ b/frontend/client/src/pages/login.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Wallet, Users, Briefcase, ArrowRight } from "lucide-react";
+import { Wallet, Users, Briefcase, ArrowRight, Home } from "lucide-react";
 import ParticleBackground from "@/components/particle-background";
 
 const FloatingIcon = ({ icon, className, delay = 0 }: { icon: React.ReactNode; className: string; delay?: number }) => (
@@ -76,6 +76,25 @@ export default function Login() {
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center p-4 relative overflow-hidden">
       <div className="absolute inset-0 blockchain-grid opacity-10"></div>
       <ParticleBackground />
+      
+      {/* Back to Home Button */}
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        className="absolute top-6 right-6 z-20"
+      >
+        <Link href="/">
+          <Button
+            variant="outline"
+            size="sm"
+            className="glass-morphism border-border/30 hover:border-primary/50 hover:bg-primary/10 transition-all duration-300 hover:scale-105 shadow-lg backdrop-blur-md"
+          >
+            <Home className="w-4 h-4 mr-2" />
+            Back to Home
+          </Button>
+        </Link>
+      </motion.div>
       
       {/* Floating Icons */}
       <div className="absolute inset-0 z-5">

--- a/frontend/client/src/pages/signup.tsx
+++ b/frontend/client/src/pages/signup.tsx
@@ -7,7 +7,7 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Wallet, Users, Briefcase, ArrowRight, User, Mail, Lock, Eye, EyeOff } from "lucide-react";
+import { Wallet, Users, Briefcase, ArrowRight, User, Mail, Lock, Eye, EyeOff, Home } from "lucide-react";
 import ParticleBackground from "@/components/particle-background";
 
 const FloatingIcon = ({ icon, className, delay = 0 }: { icon: React.ReactNode; className: string; delay?: number }) => (
@@ -113,6 +113,25 @@ export default function Signup() {
     <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center p-4 relative overflow-hidden">
       <div className="absolute inset-0 blockchain-grid opacity-10"></div>
       <ParticleBackground />
+      
+      {/* Back to Home Button */}
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.3 }}
+        className="absolute top-6 right-6 z-20"
+      >
+        <Link href="/">
+          <Button
+            variant="outline"
+            size="sm"
+            className="glass-morphism border-border/30 hover:border-primary/50 hover:bg-primary/10 transition-all duration-300 hover:scale-105 shadow-lg backdrop-blur-md"
+          >
+            <Home className="w-4 h-4 mr-2" />
+            Back to Home
+          </Button>
+        </Link>
+      </motion.div>
       
       {/* Floating Icons */}
       <div className="absolute inset-0 z-5">


### PR DESCRIPTION
This pull request adds a "Back to Home" button to the top-right corner of the login, signup, and forgot password pages, improving navigation and user experience. The button uses the new `Home` icon from `lucide-react` and features a smooth entrance animation and updated styling for visual consistency.

**Navigation Improvements:**

* Added a "Back to Home" button with entrance animation and glass-morphism styling to the top-right corner of the `login.tsx`, `signup.tsx`, and `forgot-password.tsx` pages, allowing users to easily return to the homepage. [[1]](diffhunk://#diff-51b34b5286b7485776749196c946eac71e75c65fd38698b5600b743e5615fad5R80-R98) [[2]](diffhunk://#diff-c027534e8a5fc0a90af560df94143fadab39c6260358a5f1a283ef763b90d49aR117-R135) [[3]](diffhunk://#diff-d67ac2f2d1323516498e0f258b96952906155cf11d1a675090a40a8e37a2aa6eR352-R370)

**Icon Updates:**

* Imported the `Home` icon from `lucide-react` in all three pages to support the new navigation button. [[1]](diffhunk://#diff-51b34b5286b7485776749196c946eac71e75c65fd38698b5600b743e5615fad5L9-R9) [[2]](diffhunk://#diff-c027534e8a5fc0a90af560df94143fadab39c6260358a5f1a283ef763b90d49aL10-R10) [[3]](diffhunk://#diff-d67ac2f2d1323516498e0f258b96952906155cf11d1a675090a40a8e37a2aa6eL8-R8)